### PR TITLE
Allow tips to be any type.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "react/no-danger": 0,
     "jsx-quotes": 2,
     "indent": [2, 2, {"SwitchCase": 1}],
+    "no-nested-ternary": 0,
     "no-unused-expressions": 0,
     "no-undef": 0,
     "prefer-arrow-callback": [0, { "allowNamedFunctions": true }],

--- a/lib/jsondiff-for-react.js
+++ b/lib/jsondiff-for-react.js
@@ -30,10 +30,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /**
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                * Created by guoguangyu on 2016/10/25.
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                */
-
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var formatters = Jsondiffpatch.formatters;
 
@@ -56,7 +53,8 @@ var JsonDiffReact = function (_Component) {
           show = _props$show === undefined ? true : _props$show,
           _props$annotated = _props.annotated,
           annotated = _props$annotated === undefined ? false : _props$annotated,
-          tips = _props.tips,
+          _props$tips = _props.tips,
+          tips = _props$tips === undefined ? "Both objects are identical." : _props$tips,
           objectHash = _props.objectHash;
 
       var delta = Jsondiffpatch.create({
@@ -64,11 +62,11 @@ var JsonDiffReact = function (_Component) {
       }).diff(left, right);
       var html = annotated ? formatters.annotated.format(delta) : formatters.html.format(delta, left);
       show ? formatters.html.showUnchanged() : formatters.html.hideUnchanged();
-      return html ? _react2.default.createElement("div", { dangerouslySetInnerHTML: { __html: html } }) : _react2.default.createElement(
+      return html ? _react2.default.createElement("div", { dangerouslySetInnerHTML: { __html: html } }) : typeof tips === "string" ? _react2.default.createElement(
         "p",
         { style: { fontSize: 12, color: "#999" } },
-        tips || "Both objects are identical."
-      );
+        tips
+      ) : tips;
     }
   }]);
 
@@ -80,7 +78,7 @@ JsonDiffReact.propTypes = {
   left: _propTypes2.default.any,
   show: _propTypes2.default.bool,
   annotated: _propTypes2.default.bool,
-  tips: _propTypes2.default.string,
+  tips: _propTypes2.default.any,
   objectHash: _propTypes2.default.func
 };
 exports.default = JsonDiffReact;

--- a/src/jsondiff-for-react.js
+++ b/src/jsondiff-for-react.js
@@ -12,7 +12,7 @@ class JsonDiffReact extends Component {
     left: PropTypes.any,
     show: PropTypes.bool,
     annotated: PropTypes.bool,
-    tips: PropTypes.string,
+    tips: PropTypes.any,
     objectHash: PropTypes.func,
   };
   render() {
@@ -21,7 +21,7 @@ class JsonDiffReact extends Component {
       left,
       show = true,
       annotated = false,
-      tips,
+      tips = "Both objects are identical.",
       objectHash,
     } = this.props;
     const delta = Jsondiffpatch.create({
@@ -33,10 +33,10 @@ class JsonDiffReact extends Component {
     show ? formatters.html.showUnchanged() : formatters.html.hideUnchanged();
     return html ? (
       <div dangerouslySetInnerHTML={{ __html: html }} />
+    ) : typeof tips === "string" ? (
+      <p style={{ fontSize: 12, color: "#999" }}>{tips}</p>
     ) : (
-      <p style={{ fontSize: 12, color: "#999" }}>
-        {tips || "Both objects are identical."}
-      </p>
+      tips
     );
   }
 }


### PR DESCRIPTION
The value `tips` is a fallback value displayed if the two objects have no differences.  Currently it's restricted to be a string.  However, this module is a React component, so I see no reason to not allow `tips` to be any arbitrary React object, for those who want more customization.

This PR allows `tips` to have any type.  If the value is absent, it defaults to the same string message as already exists.  If a string, it is formatted the way it already is.  However, it can also be anything else React might display, in which case that value is directly used without additional formatting.  This change should therefore be backwards compatible with all existing (valid) uses.